### PR TITLE
Fix WP Feature API Adapter

### DIFF
--- a/includes/Core/WpFeaturesAdapter.php
+++ b/includes/Core/WpFeaturesAdapter.php
@@ -47,7 +47,7 @@ class WpFeaturesAdapter {
 			);
 
 			if ( $feature->has_rest_alias() ) {
-				$the_feature['rest_alias']['route']  = $feature->get_the_rest_alias();
+				$the_feature['rest_alias']['route']  = $feature->get_rest_alias();
 				$the_feature['rest_alias']['method'] = $feature->get_rest_method();
 			} else {
 				$the_feature['callback'] = function ( $args ) use ( $feature ) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
         "eslint": "^9.25.1",
         "eslint-import-resolver-node": "0.3.9",
         "eslint-plugin-eslint-comments": "3.2.0",
-        "prettier": "npm:wp-prettier@3.5.3"
+        "prettier": "npm:wp-prettier@3.0.3"
     }
 }


### PR DESCRIPTION
This is a fix from @Jameswlepage. The feature adapter was using an incorrect function `get_the_rest_alias` instead of `get_rest_alias`.

The method `get_rest_alias` also needs to be public in the WP Feature API. I am opening a PR there too.