### PR TITLE
Bugfixes

### DIFF
--- a/includes/Tools/McpPostsTools.php
+++ b/includes/Tools/McpPostsTools.php
@@ -51,10 +51,28 @@ class McpPostsTools {
 				'description' => 'Add a new WordPress post',
 				'type'        => 'create',
 				'rest_alias'  => array(
-					'route'  => '/wp/v2/posts',
-					'method' => 'POST',
+					'route'                   => '/wp/v2/posts',
+					'method'                  => 'POST',
+					'inputSchemaReplacements' => array( // this will replace the defined elements in the default input schema with the new ones.
+						'properties' => array(
+							'title'   => array(
+								'type' => 'string',
+							),
+							'content' => array(
+								'type'        => 'string',
+								'description' => 'The content of the post in a valid Guttenberg block format',
+							),
+							'excerpt' => array(
+								'type' => 'string',
+							),
+						),
+						'required'   => array(
+							'title',
+							'content',
+						),
+					),
 				),
-			)
+			),
 		);
 
 		new RegisterMcpTool(

--- a/includes/Tools/McpUsersTools.php
+++ b/includes/Tools/McpUsersTools.php
@@ -27,8 +27,16 @@ class McpUsersTools {
 				'description' => 'Search and filter WordPress users with pagination',
 				'type'        => 'read',
 				'rest_alias'  => array(
-					'route'  => '/wp/v2/users',
-					'method' => 'GET',
+					'route'                   => '/wp/v2/users',
+					'method'                  => 'GET',
+					'inputSchemaReplacements' => array(
+						'properties' => array(
+							'has_published_posts' => array(
+								'items'   => null, // this will remove the array from the schema.
+								'default' => false,
+							),
+						),
+					),
 				),
 			)
 		);


### PR DESCRIPTION
Input chema from WordPress REST API is not fully compatible with the tools/functions on Claude and OpenAI.

Modifications:
1) If `inputSchema.properties.type` is an array, I will naively get only the first element in the array. 
2) I've added the possibility of modifying the InputSchema if a rest_alias is used.
    - If an element in the array is set to `null`, that element will be removed from the array

Implementations:
1) `wp_add_post` tool: 
    - Modified the type of `title`, `content`, and `excerpt` to string
    - Improved the description of `content`
2) `wp_users_search` tool:
    - Removed the `items` property by setting it to null
    - Set the default value to `false`