### PR TITLE
Add annotations for various tools in MCP

### DIFF
--- a/includes/Tools/McpCustomPostTypesTools.php
+++ b/includes/Tools/McpCustomPostTypesTools.php
@@ -40,6 +40,11 @@ class McpCustomPostTypesTools {
 					'route'  => '/wp/v2/types',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'List Post Types',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -83,6 +88,11 @@ class McpCustomPostTypesTools {
 						'post_type',
 					),
 				),
+				'annotations' => array(
+					'title'         => 'Search Custom Post Types',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -108,6 +118,11 @@ class McpCustomPostTypesTools {
 						'post_type',
 						'id',
 					),
+				),
+				'annotations' => array(
+					'title'         => 'Get Custom Post Type',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -147,6 +162,13 @@ class McpCustomPostTypesTools {
 						'title',
 						'content',
 					),
+				),
+				'annotations' => array(
+					'title'           => 'Add Custom Post Type',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -190,6 +212,13 @@ class McpCustomPostTypesTools {
 						'id',
 					),
 				),
+				'annotations' => array(
+					'title'           => 'Update Custom Post Type',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -215,6 +244,13 @@ class McpCustomPostTypesTools {
 						'post_type',
 						'id',
 					),
+				),
+				'annotations' => array(
+					'title'           => 'Delete Custom Post Type',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);

--- a/includes/Tools/McpMediaTools.php
+++ b/includes/Tools/McpMediaTools.php
@@ -30,6 +30,11 @@ class McpMediaTools {
 					'route'  => '/wp/v2/media',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'List Media',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -47,6 +52,11 @@ class McpMediaTools {
 							'context',
 						),
 					),
+				),
+				'annotations' => array(
+					'title'         => 'Get Media',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -73,6 +83,11 @@ class McpMediaTools {
 					'required'   => array(
 						'id',
 					),
+				),
+				'annotations'          => array(
+					'title'         => 'Get Media File',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -114,6 +129,13 @@ class McpMediaTools {
 					),
 					'preCallback'             => array( $this, 'wp_upload_media_pre_callback' ),
 				),
+				'annotations' => array(
+					'title'           => 'Upload Media',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -146,6 +168,13 @@ class McpMediaTools {
 						),
 					),
 				),
+				'annotations' => array(
+					'title'           => 'Update Media',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -157,6 +186,13 @@ class McpMediaTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/media/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Media',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -193,6 +229,11 @@ class McpMediaTools {
 							),
 						),
 					),
+				),
+				'annotations' => array(
+					'title'         => 'Search Media',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);

--- a/includes/Tools/McpPagesTools.php
+++ b/includes/Tools/McpPagesTools.php
@@ -30,6 +30,11 @@ class McpPagesTools {
 					'route'  => '/wp/v2/pages',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Search Pages',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -41,6 +46,11 @@ class McpPagesTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/pages/(?P<id>[\d]+)',
 					'method' => 'GET',
+				),
+				'annotations' => array(
+					'title'         => 'Get Page',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -80,6 +90,13 @@ class McpPagesTools {
 						),
 					),
 				),
+				'annotations' => array(
+					'title'           => 'Add Page',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
+				),
 			),
 		);
 
@@ -92,6 +109,13 @@ class McpPagesTools {
 					'route'  => '/wp/v2/pages/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update Page',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -103,6 +127,13 @@ class McpPagesTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/pages/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Page',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);

--- a/includes/Tools/McpPostsTools.php
+++ b/includes/Tools/McpPostsTools.php
@@ -30,6 +30,11 @@ class McpPostsTools {
 					'route'  => '/wp/v2/posts',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Search Posts',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -41,6 +46,11 @@ class McpPostsTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/posts/(?P<id>[\d]+)',
 					'method' => 'GET',
+				),
+				'annotations' => array(
+					'title'         => 'Get Post',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -72,6 +82,13 @@ class McpPostsTools {
 						),
 					),
 				),
+				'annotations' => array(
+					'title'           => 'Add Post',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
+				),
 			),
 		);
 
@@ -84,6 +101,13 @@ class McpPostsTools {
 					'route'  => '/wp/v2/posts/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update Post',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -95,6 +119,13 @@ class McpPostsTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/posts/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Post',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -109,6 +140,11 @@ class McpPostsTools {
 					'route'  => '/wp/v2/categories',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'List Categories',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -121,6 +157,13 @@ class McpPostsTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/categories',
 					'method' => 'POST',
+				),
+				'annotations' => array(
+					'title'           => 'Add Category',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -135,6 +178,13 @@ class McpPostsTools {
 					'route'  => '/wp/v2/categories/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update Category',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -147,6 +197,13 @@ class McpPostsTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/categories/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Category',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -161,6 +218,11 @@ class McpPostsTools {
 					'route'  => '/wp/v2/tags',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'List Tags',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -173,6 +235,13 @@ class McpPostsTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/tags',
 					'method' => 'POST',
+				),
+				'annotations' => array(
+					'title'           => 'Add Tag',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -187,6 +256,13 @@ class McpPostsTools {
 					'route'  => '/wp/v2/tags/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update Tag',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -199,6 +275,13 @@ class McpPostsTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/tags/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Tag',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);

--- a/includes/Tools/McpSettingsTools.php
+++ b/includes/Tools/McpSettingsTools.php
@@ -30,6 +30,11 @@ class McpSettingsTools {
 					'route'  => '/wp/v2/settings',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Get General Settings',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -97,6 +102,13 @@ class McpSettingsTools {
 							),
 						),
 					),
+				),
+				'annotations' => array(
+					'title'           => 'Update General Settings',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);

--- a/includes/Tools/McpSiteInfo.php
+++ b/includes/Tools/McpSiteInfo.php
@@ -39,6 +39,11 @@ class McpSiteInfo {
 				),
 				'callback'             => array( $this, 'get_site_info' ),
 				'permissions_callback' => array( $this, 'permissions_callback' ),
+				'annotations'          => array(
+					'title'         => 'Get Site Info',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 	}

--- a/includes/Tools/McpUsersTools.php
+++ b/includes/Tools/McpUsersTools.php
@@ -41,6 +41,11 @@ class McpUsersTools {
 						),
 					),
 				),
+				'annotations' => array(
+					'title'         => 'Search Users',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -52,6 +57,11 @@ class McpUsersTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/users/(?P<id>[\d]+)',
 					'method' => 'GET',
+				),
+				'annotations' => array(
+					'title'         => 'Get User',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -73,6 +83,13 @@ class McpUsersTools {
 						),
 					),
 				),
+				'annotations' => array(
+					'title'           => 'Add User',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -85,6 +102,13 @@ class McpUsersTools {
 					'route'  => '/wp/v2/users/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update User',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -96,6 +120,13 @@ class McpUsersTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/users/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete User',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -110,6 +141,11 @@ class McpUsersTools {
 					'route'  => '/wp/v2/users/me',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Get Current User',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -122,6 +158,13 @@ class McpUsersTools {
 				'rest_alias'  => array(
 					'route'  => '/wp/v2/users/me',
 					'method' => 'PUT',
+				),
+				'annotations' => array(
+					'title'           => 'Update Current User',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);

--- a/includes/Tools/McpWooOrders.php
+++ b/includes/Tools/McpWooOrders.php
@@ -41,6 +41,11 @@ class McpWooOrders {
 					'route'  => '/wc/v3/orders',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Search Orders',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -54,6 +59,11 @@ class McpWooOrders {
 					'route'  => '/wc/v3/reports/coupons/totals',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Get Coupons Report',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -65,6 +75,11 @@ class McpWooOrders {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/reports/customers/totals',
 					'method' => 'GET',
+				),
+				'annotations' => array(
+					'title'         => 'Get Customers Report',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -78,6 +93,11 @@ class McpWooOrders {
 					'route'  => '/wc/v3/reports/orders/totals',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Get Orders Report',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -89,6 +109,11 @@ class McpWooOrders {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/reports/products/totals',
 					'method' => 'GET',
+				),
+				'annotations' => array(
+					'title'         => 'Get Products Report',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -102,6 +127,11 @@ class McpWooOrders {
 					'route'  => '/wc/v3/reports/reviews/totals',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Get Reviews Report',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -113,6 +143,11 @@ class McpWooOrders {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/reports/sales',
 					'method' => 'GET',
+				),
+				'annotations' => array(
+					'title'         => 'Get Sales Report',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);

--- a/includes/Tools/McpWooProducts.php
+++ b/includes/Tools/McpWooProducts.php
@@ -41,6 +41,11 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'Search Products',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -52,6 +57,11 @@ class McpWooProducts {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/products/(?P<id>[\d]+)',
 					'method' => 'GET',
+				),
+				'annotations' => array(
+					'title'         => 'Get Product',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
 				),
 			)
 		);
@@ -65,6 +75,13 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products',
 					'method' => 'POST',
 				),
+				'annotations' => array(
+					'title'           => 'Add Product',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -77,6 +94,13 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update Product',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -88,6 +112,13 @@ class McpWooProducts {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/products/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Product',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -102,6 +133,11 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products/categories',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'List Product Categories',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -113,6 +149,13 @@ class McpWooProducts {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/products/categories',
 					'method' => 'POST',
+				),
+				'annotations' => array(
+					'title'           => 'Add Product Category',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -126,6 +169,13 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products/categories/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update Product Category',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -137,6 +187,13 @@ class McpWooProducts {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/products/categories/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Product Category',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -151,6 +208,11 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products/tags',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'List Product Tags',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -162,6 +224,13 @@ class McpWooProducts {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/products/tags',
 					'method' => 'POST',
+				),
+				'annotations' => array(
+					'title'           => 'Add Product Tag',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -175,6 +244,13 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products/tags/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update Product Tag',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -186,6 +262,13 @@ class McpWooProducts {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/products/tags/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Product Tag',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -200,6 +283,11 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products/brands',
 					'method' => 'GET',
 				),
+				'annotations' => array(
+					'title'         => 'List Product Brands',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
 			)
 		);
 
@@ -211,6 +299,13 @@ class McpWooProducts {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/products/brands',
 					'method' => 'POST',
+				),
+				'annotations' => array(
+					'title'           => 'Add Product Brand',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
 				),
 			)
 		);
@@ -224,6 +319,13 @@ class McpWooProducts {
 					'route'  => '/wc/v3/products/brands/(?P<id>[\d]+)',
 					'method' => 'PUT',
 				),
+				'annotations' => array(
+					'title'           => 'Update Product Brand',
+					'readOnlyHint'    => false,
+					'destructiveHint' => false,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
 			)
 		);
 
@@ -235,6 +337,13 @@ class McpWooProducts {
 				'rest_alias'  => array(
 					'route'  => '/wc/v3/products/brands/(?P<id>[\d]+)',
 					'method' => 'DELETE',
+				),
+				'annotations' => array(
+					'title'           => 'Delete Product Brand',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
 				),
 			)
 		);


### PR DESCRIPTION
- Introduced 'annotations' for custom post types, media, pages, posts, settings, users, and WooCommerce tools.
- Each annotation includes a title, readOnlyHint, destructiveHint, idempotentHint, and openWorldHint for improved API documentation and usability.