### PR TITLE
Add per-tool enable/disable settings

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -179,11 +179,15 @@ class Settings {
 			$sanitized['enable_update_tools'] = false;
 		}
 
-		if ( isset( $input['enable_delete_tools'] ) ) {
-			$sanitized['enable_delete_tools'] = (bool) $input['enable_delete_tools'];
-		} else {
-			$sanitized['enable_delete_tools'] = false;
-		}
+                if ( isset( $input['enable_delete_tools'] ) ) {
+                        $sanitized['enable_delete_tools'] = (bool) $input['enable_delete_tools'];
+                } else {
+                        $sanitized['enable_delete_tools'] = false;
+                }
+
+                if ( isset( $input['enabled_tools'] ) ) {
+                        $sanitized['enabled_tools'] = array_map( 'sanitize_text_field', (array) $input['enabled_tools'] );
+                }
 
 		return $sanitized;
 	}

--- a/includes/Core/McpProxyRoutes.php
+++ b/includes/Core/McpProxyRoutes.php
@@ -178,17 +178,18 @@ class McpProxyRoutes {
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function list_tools( array $params ): WP_Error|WP_REST_Response {
+        public function list_tools( array $params ): WP_Error|WP_REST_Response {
 
-		// Implement tool listing logic here.
-		$tools = $this->mcp->get_tools();
+                $show_all = ! empty( $params['all'] ) && current_user_can( 'manage_options' );
 
-		return rest_ensure_response(
-			array(
-				'tools' => $tools,
-			)
-		);
-	}
+                $tools = $show_all ? $this->mcp->get_tools() : $this->mcp->get_enabled_tools();
+
+                return rest_ensure_response(
+                        array(
+                                'tools' => $tools,
+                        )
+                );
+        }
 
 	/**
 	 * Call a tool
@@ -197,14 +198,22 @@ class McpProxyRoutes {
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function call_tool( array $params ): WP_Error|WP_REST_Response {
-		if ( ! isset( $params['name'] ) ) {
-			return new WP_Error(
-				'missing_parameter',
-				'Missing required parameter: name',
-				array( 'status' => 400 )
-			);
-		}
+        public function call_tool( array $params ): WP_Error|WP_REST_Response {
+                if ( ! isset( $params['name'] ) ) {
+                        return new WP_Error(
+                                'missing_parameter',
+                                'Missing required parameter: name',
+                                array( 'status' => 400 )
+                        );
+                }
+
+                if ( ! $this->mcp->is_tool_enabled( $params['name'] ) ) {
+                        return new WP_Error(
+                                'tool_disabled',
+                                'The requested tool is disabled.',
+                                array( 'status' => 403 )
+                        );
+                }
 
 		// Implement a tool calling logic here.
 		$result = HandleToolsCall::run( $params );

--- a/includes/Core/WpMcp.php
+++ b/includes/Core/WpMcp.php
@@ -214,7 +214,7 @@ class WpMcp {
 	 * @param string $type The tool type to check.
 	 * @return bool Whether the tool type is enabled.
 	 */
-	private function is_tool_type_enabled( string $type ): bool {
+        private function is_tool_type_enabled( string $type ): bool {
 
 		// Read operations are always allowed if MCP is enabled.
 		if ( 'read' === $type ) {
@@ -233,8 +233,45 @@ class WpMcp {
 			return isset( $this->mcp_settings[ $type_settings_map[ $type ] ] ) && $this->mcp_settings[ $type_settings_map[ $type ] ];
 		}
 
-		return false;
-	}
+                return false;
+        }
+
+        /**
+         * Check if a specific tool is enabled via settings.
+         *
+         * @param string $name The tool name.
+         * @return bool Whether the tool is enabled.
+         */
+        public function is_tool_enabled( string $name ): bool {
+                if ( ! isset( $this->mcp_settings['enabled_tools'] ) || ! is_array( $this->mcp_settings['enabled_tools'] ) ) {
+                        return true;
+                }
+
+                if ( empty( $this->mcp_settings['enabled_tools'] ) ) {
+                        return false;
+                }
+
+                return in_array( $name, $this->mcp_settings['enabled_tools'], true );
+        }
+
+        /**
+         * Get only tools enabled via settings.
+         *
+         * @return array
+         */
+        public function get_enabled_tools(): array {
+                if ( ! isset( $this->mcp_settings['enabled_tools'] ) || ! is_array( $this->mcp_settings['enabled_tools'] ) ) {
+                        return $this->tools;
+                }
+
+                if ( empty( $this->mcp_settings['enabled_tools'] ) ) {
+                        return array();
+                }
+
+                return array_values( array_filter( $this->tools, function ( $tool ) {
+                        return in_array( $tool['name'], $this->mcp_settings['enabled_tools'], true );
+                } ) );
+        }
 
 	/**
 	 * Register a tool.

--- a/src/settings/ToolsTab.js
+++ b/src/settings/ToolsTab.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Card, CardHeader, CardBody, Spinner } from '@wordpress/components';
+import { Card, CardHeader, CardBody, Spinner, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -9,8 +9,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Tools Tab Component
  */
-const ToolsTab = () => {
-	const [ tools, setTools ] = useState( [] );
+const ToolsTab = ( { enabledTools, onToggleTool, mcpEnabled } ) => {
+        const [ tools, setTools ] = useState( [] );
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
 
@@ -18,15 +18,15 @@ const ToolsTab = () => {
 		const fetchTools = async () => {
 			try {
 				setLoading( true );
-				const response = await apiFetch( {
-					path: '/wp/v2/wpmcp',
-					method: 'POST',
-					data: {
-						jsonrpc: '2.0',
-						method: 'tools/list',
-						params: {},
-					},
-				} );
+                                const response = await apiFetch( {
+                                        path: '/wp/v2/wpmcp',
+                                        method: 'POST',
+                                        data: {
+                                                jsonrpc: '2.0',
+                                                method: 'tools/list',
+                                                params: { all: true },
+                                        },
+                                } );
 
 				if ( response && response.tools ) {
 					setTools( response.tools );
@@ -77,32 +77,38 @@ const ToolsTab = () => {
 						) }
 					</p>
 				) : (
-					<table className="wordpress-mcp-table">
-						<thead>
-						<tr>
-							<th>{ __( 'Name', 'wordpress-mcp' ) }</th>
-							<th>
-								{ __( 'Description', 'wordpress-mcp' ) }
-							</th>
-							<th>{ __( 'Functionality Type', 'wordpress-mcp' ) }</th>
-						</tr>
-						</thead>
-						<tbody>
-						{ tools.map( ( tool ) => (
-							<tr key={ tool.name }>
-								<td>
-									<strong>{ tool.name }</strong>
-								</td>
-								<td>{ tool.description }</td>
-								<td>{ tool.type }</td>
-							</tr>
-						) ) }
-						</tbody>
-					</table>
-				) }
-			</CardBody>
-		</Card>
-	);
+                                        <table className="wordpress-mcp-table">
+                                                <thead>
+                                                <tr>
+                                                        <th>{ __( 'Name', 'wordpress-mcp' ) }</th>
+                                                        <th>{ __( 'Description', 'wordpress-mcp' ) }</th>
+                                                        <th>{ __( 'Functionality Type', 'wordpress-mcp' ) }</th>
+                                                        <th>{ __( 'Enabled', 'wordpress-mcp' ) }</th>
+                                                </tr>
+                                                </thead>
+                                                <tbody>
+                                                { tools.map( ( tool ) => (
+                                                        <tr key={ tool.name }>
+                                                                <td>
+                                                                        <strong>{ tool.name }</strong>
+                                                                </td>
+                                                                <td>{ tool.description }</td>
+                                                                <td>{ tool.type }</td>
+                                                                <td>
+                                                                        <ToggleControl
+                                                                                checked={ Array.isArray( enabledTools ) ? enabledTools.includes( tool.name ) : true }
+                                                                                onChange={ () => onToggleTool( tool.name ) }
+                                                                                disabled={ ! mcpEnabled }
+                                                                        />
+                                                                </td>
+                                                        </tr>
+                                                ) ) }
+                                                </tbody>
+                                        </table>
+                                ) }
+                        </CardBody>
+                </Card>
+        );
 };
 
 export default ToolsTab;

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -16,13 +16,14 @@ import PromptsTab from './PromptsTab';
  */
 export const SettingsApp = () => {
 	// State for settings
-	const [settings, setSettings] = useState({
-		enabled: false,
-		features_adapter_enabled: false,
-		enable_create_tools: false,
-		enable_update_tools: false,
-		enable_delete_tools: false,
-	});
+        const [settings, setSettings] = useState({
+                enabled: false,
+                features_adapter_enabled: false,
+                enable_create_tools: false,
+                enable_update_tools: false,
+                enable_delete_tools: false,
+                enabled_tools: undefined,
+        });
 
 	// State for UI
 	const [isSaving, setIsSaving] = useState(false);
@@ -50,11 +51,12 @@ export const SettingsApp = () => {
 					typeof loaded.enable_update_tools === 'boolean'
 						? loaded.enable_update_tools
 						: false,
-				enable_delete_tools:
-					typeof loaded.enable_delete_tools === 'boolean'
-						? loaded.enable_delete_tools
-						: false,
-			}));
+                                enable_delete_tools:
+                                        typeof loaded.enable_delete_tools === 'boolean'
+                                                ? loaded.enable_delete_tools
+                                                : false,
+                                enabled_tools: Array.isArray( loaded.enabled_tools ) ? loaded.enabled_tools : undefined,
+                        }));
 		}
 	}, []);
 
@@ -68,8 +70,8 @@ export const SettingsApp = () => {
 	}, []);
 
 	// Handle toggle changes
-	const handleToggleChange = (key) => {
-		const newValue = !settings[key];
+        const handleToggleChange = (key) => {
+                const newValue = !settings[key];
 
 		// Update settings state with the new value
 		setSettings((prevSettings) => {
@@ -95,8 +97,48 @@ export const SettingsApp = () => {
 			}, 500);
 
 			return updatedSettings;
-		});
-	};
+                });
+        };
+
+        const handleToolToggle = (toolName) => {
+                setSettings((prevSettings) => {
+                        const current = Array.isArray(prevSettings.enabled_tools)
+                                ? [...prevSettings.enabled_tools]
+                                : [];
+
+                        if (current.includes(toolName)) {
+                                const updated = current.filter((t) => t !== toolName);
+                                const updatedSettings = {
+                                        ...prevSettings,
+                                        enabled_tools: updated,
+                                };
+                                if (saveTimeoutRef.current) {
+                                        clearTimeout(saveTimeoutRef.current);
+                                }
+                                saveTimeoutRef.current = setTimeout(() => {
+                                        handleSaveSettingsWithData(updatedSettings);
+                                        saveTimeoutRef.current = null;
+                                }, 500);
+                                return updatedSettings;
+                        }
+
+                        const updated = [...current, toolName];
+                        const updatedSettings = {
+                                ...prevSettings,
+                                enabled_tools: updated,
+                        };
+
+                        if (saveTimeoutRef.current) {
+                                clearTimeout(saveTimeoutRef.current);
+                        }
+                        saveTimeoutRef.current = setTimeout(() => {
+                                handleSaveSettingsWithData(updatedSettings);
+                                saveTimeoutRef.current = null;
+                        }, 500);
+
+                        return updatedSettings;
+                });
+        };
 
 	// Save settings with specific data
 	const handleSaveSettingsWithData = (settingsData) => {
@@ -237,8 +279,14 @@ export const SettingsApp = () => {
 									strings={strings}
 								/>
 							);
-						case 'tools':
-							return <ToolsTab />;
+                                               case 'tools':
+                                                        return (
+                                                                <ToolsTab
+                                                                        enabledTools={settings.enabled_tools}
+                                                                        onToggleTool={handleToolToggle}
+                                                                        mcpEnabled={settings.enabled}
+                                                                />
+                                                        );
 						case 'resources':
 							return <ResourcesTab />;
 						case 'prompts':

--- a/tests/phpunit/McpToolsRegistrationTest.php
+++ b/tests/phpunit/McpToolsRegistrationTest.php
@@ -564,7 +564,7 @@ class McpToolsRegistrationTest extends WP_UnitTestCase {
 	/**
 	 * Test the tools/call endpoint with a tool that has a disabled type.
 	 */
-	public function test_call_tool_endpoint_with_disabled_type(): void {
+        public function test_call_tool_endpoint_with_disabled_type(): void {
 		// Disable create tools in settings.
 		update_option(
 			'wordpress_mcp_settings',
@@ -620,8 +620,62 @@ class McpToolsRegistrationTest extends WP_UnitTestCase {
 		// Check the response.
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertArrayHasKey( 'code', $response->get_data() );
-		$this->assertEquals( 'invalid_request', $response->get_data()['code'] );
-	}
+                $this->assertEquals( 'invalid_request', $response->get_data()['code'] );
+        }
+
+        /**
+         * Test the tools/call endpoint with a tool disabled via settings.
+         */
+        public function test_call_tool_endpoint_with_disabled_tool(): void {
+                update_option(
+                        'wordpress_mcp_settings',
+                        array(
+                                'enabled'       => true,
+                                'enabled_tools' => array(),
+                        )
+                );
+
+                add_action(
+                        'wordpress_mcp_init',
+                        function () {
+                                new RegisterMcpTool(
+                                        array(
+                                                'name'                => 'disabled_tool',
+                                                'description'         => 'A disabled tool',
+                                                'type'                => 'read',
+                                                'callback'            => function () {
+                                                        return array( 'success' => true );
+                                                },
+                                                'permission_callback' => function () {
+                                                        return current_user_can( 'manage_options' );
+                                                },
+                                                'inputSchema'         => array(
+                                                        'type'       => 'object',
+                                                        'properties' => array(),
+                                                ),
+                                        )
+                                );
+                        }
+                );
+
+                do_action( 'wordpress_mcp_init' );
+
+                $request = new WP_REST_Request( 'POST', '/wp/v2/wpmcp' );
+                $request->set_body_params(
+                        array(
+                                'method' => 'tools/call',
+                                'name'   => 'disabled_tool',
+                        )
+                );
+
+                wp_set_current_user( $this->admin_user->ID );
+
+                $response = rest_do_request( $request );
+
+                $this->assertEquals( 403, $response->get_status() );
+                $this->assertArrayHasKey( 'code', $response->get_data() );
+                $this->assertEquals( 'tool_disabled', $response->get_data()['code'] );
+        }
 
 	/**
 	 * Test the tools/call endpoint with a tool that has a non-existent REST API route.


### PR DESCRIPTION
## Summary
- allow specifying individual tools that are enabled
- hide disabled tools from remote list and block calling them
- show tool toggles in admin tools tab
- persist new `enabled_tools` setting
- test tool disabled case

## Testing
- `composer install` *(fails: command not found)*