### PR TITLE
Implement per-tool enable/disable settings (Ovi's version)

### DIFF
--- a/src/settings/ToolsTab.js
+++ b/src/settings/ToolsTab.js
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { Card, CardHeader, CardBody, Spinner } from '@wordpress/components';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	Spinner,
+	ToggleControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -13,23 +19,20 @@ const ToolsTab = () => {
 	const [ tools, setTools ] = useState( [] );
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
+	const [ saving, setSaving ] = useState( false );
 
 	useEffect( () => {
 		const fetchTools = async () => {
 			try {
 				setLoading( true );
-				const response = await apiFetch( {
-					path: '/wp/v2/wpmcp',
-					method: 'POST',
-					data: {
-						jsonrpc: '2.0',
-						method: 'tools/list',
-						params: {},
-					},
-				} );
+				const response = await fetch(
+					ajaxurl + '?action=all_mcp_tools'
+				).then( ( res ) => res.json() );
 
-				if ( response && response.tools ) {
-					setTools( response.tools );
+				console.log( 'response', response );
+
+				if ( response && response.data ) {
+					setTools( response.data );
 				} else {
 					setError(
 						__( 'Failed to load tools data', 'wordpress-mcp' )
@@ -47,6 +50,61 @@ const ToolsTab = () => {
 		fetchTools();
 	}, [] );
 
+	const handleToggleChange = async ( toolName, newState ) => {
+		try {
+			setSaving( true );
+			// Update local state immediately for better UX
+			setTools( ( prevTools ) =>
+				prevTools.map( ( tool ) =>
+					tool.name === toolName
+						? { ...tool, tool_enabled: newState }
+						: tool
+				)
+			);
+
+			// Create form data for AJAX request
+			const formData = new FormData();
+			formData.append( 'action', 'wordpress_mcp_toggle_tool' );
+			formData.append( 'nonce', window.wordpressMcpSettings.nonce );
+			formData.append( 'tool', toolName );
+			formData.append( 'tool_enabled', newState );
+
+			// Send AJAX request
+			const response = await fetch( ajaxurl, {
+				method: 'POST',
+				body: formData,
+				credentials: 'same-origin',
+			} );
+
+			const data = await response.json();
+
+			if ( ! data.success ) {
+				throw new Error(
+					data.data.message ||
+						window.wordpressMcpSettings.strings.settingsError
+				);
+			}
+
+			// Show success message
+			setError( null );
+		} catch ( err ) {
+			// Revert the state if the save fails
+			setTools( ( prevTools ) =>
+				prevTools.map( ( tool ) =>
+					tool.name === toolName
+						? { ...tool, tool_enabled: ! newState }
+						: tool
+				)
+			);
+			setError(
+				err.message || window.wordpressMcpSettings.strings.settingsError
+			);
+			console.error( 'Error saving tool state:', err );
+		} finally {
+			setSaving( false );
+		}
+	};
+
 	return (
 		<Card>
 			<CardHeader>
@@ -55,7 +113,7 @@ const ToolsTab = () => {
 			<CardBody>
 				<p>
 					{ __(
-						'List of all registered tools in the system.',
+						'List of all registered tools in the system. Use the toggles to enable or disable individual tools.',
 						'wordpress-mcp'
 					) }
 				</p>
@@ -79,24 +137,60 @@ const ToolsTab = () => {
 				) : (
 					<table className="wordpress-mcp-table">
 						<thead>
-						<tr>
-							<th>{ __( 'Name', 'wordpress-mcp' ) }</th>
-							<th>
-								{ __( 'Description', 'wordpress-mcp' ) }
-							</th>
-							<th>{ __( 'Functionality Type', 'wordpress-mcp' ) }</th>
-						</tr>
+							<tr>
+								<th>{ __( 'Name', 'wordpress-mcp' ) }</th>
+								<th>
+									{ __( 'Description', 'wordpress-mcp' ) }
+								</th>
+								<th>
+									{ __(
+										'Functionality Type',
+										'wordpress-mcp'
+									) }
+								</th>
+								<th>{ __( 'Status', 'wordpress-mcp' ) }</th>
+							</tr>
 						</thead>
 						<tbody>
-						{ tools.map( ( tool ) => (
-							<tr key={ tool.name }>
-								<td>
-									<strong>{ tool.name }</strong>
-								</td>
-								<td>{ tool.description }</td>
-								<td>{ tool.type }</td>
-							</tr>
-						) ) }
+							{ tools.map( ( tool ) => (
+								<tr key={ tool.name }>
+									<td>
+										<strong>{ tool.name }</strong>
+									</td>
+									<td>{ tool.description }</td>
+									<td>{ tool.type }</td>
+									<td>
+										<ToggleControl
+											checked={
+												tool.tool_enabled &&
+												tool.tool_type_enabled
+											}
+											onChange={ ( value ) =>
+												handleToggleChange(
+													tool.name,
+													value
+												)
+											}
+											disabled={
+												saving ||
+												! tool.tool_type_enabled
+											}
+											label={
+												tool.tool_enabled &&
+												tool.tool_type_enabled
+													? __(
+															'Enabled',
+															'wordpress-mcp'
+													  )
+													: __(
+															'Disabled',
+															'wordpress-mcp'
+													  )
+											}
+										/>
+									</td>
+								</tr>
+							) ) }
 						</tbody>
 					</table>
 				) }


### PR DESCRIPTION
- Added methods to toggle tool states and retrieve all tools via AJAX.
- Introduced a new constant for tool states option in the Settings class.
- Updated the ToolsTab component to include toggle controls for enabling/disabling tools.
- Enhanced the WpMcp class to manage tool states and check if tools are enabled.