### PR TITLE
Add license references, update header values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "ovidiugalatan/wordpress-mcp",
     "description": "WordPress MCP Plugin",
     "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "yoast/phpunit-polyfills": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,10 @@
 {
-    "name": "ovidiugalatan/wordpress-mcp",
-    "description": "WordPress MCP Plugin",
+    "name": "automattic/wordpress-mcp",
+    "description": "A plugin to integrate WordPress with Model Context Protocol (MCP), providing AI-accessible interfaces to WordPress data and functionality through standardized tools, resources, and prompts. Enables AI assistants to interact with posts, users, site settings, and WooCommerce data.",
     "type": "wordpress-plugin",
+    "homepage": "https://github.com/Automattic/wordpress-mcp",
     "license": "GPL-2.0-or-later",
+    "author": "Automattic AI  (https://automattic.ai)",
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "yoast/phpunit-polyfills": "^1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,16 @@
 {
 	"name": "wordpress-mcp",
 	"version": "0.1.18",
-	"description": "Wordpress MCP Settings",
+	"description": "A plugin to integrate WordPress with Model Context Protocol (MCP), providing AI-accessible interfaces to WordPress data and functionality through standardized tools, resources, and prompts. Enables AI assistants to interact with posts, users, site settings, and WooCommerce data.",
+	"keywords": [
+		"wordpress",
+		"mcp",
+		"content",
+		"management"
+	],
+	"homepage": "https://github.com/Automattic/wordpress-mcp",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic AI  (https://automattic.ai)",
 	"main": "src/index.js",
 	"private": true,
 	"scripts": {
@@ -14,14 +23,6 @@
 		"plugin-zip": "wp-scripts plugin-zip",
 		"clean": "rm -rf build"
 	},
-	"keywords": [
-		"wordpress",
-		"mcp",
-		"content",
-		"management"
-	],
-	"author": "Automattic",
-	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"@wordpress/api-fetch": "^7.22.0",
 		"@wordpress/components": "^29.8.0",

--- a/wordpress-mcp.php
+++ b/wordpress-mcp.php
@@ -5,6 +5,8 @@
  * Version: 0.1.18
  * Author: Automattic AI, Ovidiu Galatan <ovidiu.galatan@a8c.com>
  * Author URI: https://automattic.ai
+ * License: GPL-2.0-or-later
+ * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
  * Text Domain: wordpress-mcp
  * Domain Path: /languages
  * Requires PHP: 8.0

--- a/wordpress-mcp.php
+++ b/wordpress-mcp.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * Plugin name: WordPress MCP
- * Description: A plugin to integrate WordPress with Model Context Protocol (MCP), providing AI-accessible interfaces to WordPress data and functionality through standardized tools, resources, and prompts. Enables AI assistants to interact with posts, users, site settings, and WooCommerce data.
- * Version: 0.1.18
- * Author: Automattic AI, Ovidiu Galatan <ovidiu.galatan@a8c.com>
- * Author URI: https://automattic.ai
- * License: GPL-2.0-or-later
- * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
- * Text Domain: wordpress-mcp
- * Domain Path: /languages
- * Requires PHP: 8.0
+ * Plugin name:       WordPress MCP
+ * Description:       A plugin to integrate WordPress with Model Context Protocol (MCP), providing AI-accessible interfaces to WordPress data and functionality through standardized tools, resources, and prompts. Enables AI assistants to interact with posts, users, site settings, and WooCommerce data.
+ * Version:           0.1.18
+ * Requires at least: 6.4
+ * Requires PHP:      8.0
+ * Author:            Automattic AI, Ovidiu Galatan <ovidiu.galatan@a8c.com>
+ * Author URI:        https://automattic.ai
+ * License:           GPL-2.0-or-later
+ * License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
+ * Text Domain:       wordpress-mcp
+ * Domain Path:       /languages
  *
  * @package WordPress MCP
  */


### PR DESCRIPTION
This pull request updates metadata across several files to align the plugin's branding and licensing with Automattic's standards and enhance its description for clarity and consistency. The changes include updates to the plugin's name, description, author information, license, and other metadata fields.

### Metadata updates for branding and licensing:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L2-R7): Updated the plugin name to `automattic/wordpress-mcp`, improved the description to highlight MCP integration and AI capabilities, added homepage, license, and author information.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R13): Enhanced the description to match the updated branding, added keywords, homepage, license, and author details. Removed redundant metadata fields. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R13) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-L24)
* [`wordpress-mcp.php`](diffhunk://#diff-759b884bb4fdaa4208a011f0d21269e8c40658d4a841282d7977c9e64a03978eR6-L10): Added minimum WordPress and PHP version requirements, updated license information, and refined author details for consistency.

### Rationale

* License info was inferred from https://github.com/Automattic/wordpress-mcp/blob/6a9ac934897a2f503e383d3263dbea95b43937bc/package.json#L24
* WP and PHP minimums inferred from https://github.com/Automattic/wordpress-mcp/tree/trunk/docs#requirements
* WP plugin file header requirements inferred from https://developer.wordpress.org/plugins/plugin-basics/header-requirements/
* Composer file header requirements inferred from https://getcomposer.org/doc/04-schema.md
* Package file header requirements inferred from https://docs.npmjs.com/cli/v11/configuring-npm/package-json