### PR TITLE
Implement REST API CRUD Tools and Update Settings

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -127,6 +127,8 @@ class Settings {
 					'enableUpdateToolsDescription'     => __( 'Allow update operations via tools.', 'wordpress-mcp' ),
 					'enableDeleteTools'                => __( 'Enable Delete Tools', 'wordpress-mcp' ),
 					'enableDeleteToolsDescription'     => __( '⚠️ CAUTION: Allow deletion operations via tools.', 'wordpress-mcp' ),
+					'enableRestApiCrudTools'           => __( '🧪 Enable REST API CRUD Tools (EXPERIMENTAL)', 'wordpress-mcp' ),
+					'enableRestApiCrudToolsDescription' => __( '⚠️ EXPERIMENTAL FEATURE: Enable or disable the generic REST API CRUD tools for accessing WordPress endpoints. This is experimental functionality that may change or be removed in future versions. When enabled, all tools that are a rest_alias or have the disabled_by_rest_crud flag will be disabled.', 'wordpress-mcp' ),
 					'saveSettings'                     => __( 'Save Settings', 'wordpress-mcp' ),
 					'settingsSaved'                    => __( 'Settings saved successfully!', 'wordpress-mcp' ),
 					'settingsError'                    => __( 'Error saving settings. Please try again.', 'wordpress-mcp' ),
@@ -195,6 +197,12 @@ class Settings {
 			$sanitized['enable_delete_tools'] = (bool) $input['enable_delete_tools'];
 		} else {
 			$sanitized['enable_delete_tools'] = false;
+		}
+
+		if ( isset( $input['enable_rest_api_crud_tools'] ) ) {
+			$sanitized['enable_rest_api_crud_tools'] = (bool) $input['enable_rest_api_crud_tools'];
+		} else {
+			$sanitized['enable_rest_api_crud_tools'] = false;
 		}
 
 		return $sanitized;

--- a/includes/Core/RegisterMcpTool.php
+++ b/includes/Core/RegisterMcpTool.php
@@ -186,8 +186,8 @@ class RegisterMcpTool {
 			throw new InvalidArgumentException( 'The functionality type is required.' );
 		}
 
-		// validate functionality type: must be one of 'create', 'read', 'update', 'delete'.
-		$valid_types = array( 'create', 'read', 'update', 'delete' );
+		// validate functionality type: must be one of 'create', 'read', 'update', 'delete', 'action'.
+		$valid_types = array( 'create', 'read', 'update', 'delete', 'action' );
 		if ( ! in_array( $this->args['type'], $valid_types, true ) ) {
 			throw new InvalidArgumentException( 'The functionality type must be one of: ' . esc_html( implode( ', ', $valid_types ) ) );
 		}

--- a/includes/Tools/McpCustomPostTypesTools.php
+++ b/includes/Tools/McpCustomPostTypesTools.php
@@ -55,6 +55,7 @@ class McpCustomPostTypesTools {
 				'type'                => 'read',
 				'callback'            => array( $this, 'search_custom_post_types' ),
 				'permission_callback' => array( $this, 'search_custom_post_types_permission_callback' ),
+				'disabled_by_rest_crud' => true,
 				'inputSchema'         => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -104,6 +105,7 @@ class McpCustomPostTypesTools {
 				'type'                => 'read',
 				'callback'            => array( $this, 'get_custom_post_type' ),
 				'permission_callback' => array( $this, 'get_custom_post_type_permission_callback' ),
+				'disabled_by_rest_crud' => true,
 				'inputSchema'         => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -136,6 +138,7 @@ class McpCustomPostTypesTools {
 				'type'                => 'create',
 				'callback'            => array( $this, 'add_custom_post_type' ),
 				'permission_callback' => array( $this, 'add_custom_post_type_permission_callback' ),
+				'disabled_by_rest_crud' => true,
 				'inputSchema'         => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -183,6 +186,7 @@ class McpCustomPostTypesTools {
 				'type'                => 'update',
 				'callback'            => array( $this, 'update_custom_post_type' ),
 				'permission_callback' => array( $this, 'update_custom_post_type_permission_callback' ),
+				'disabled_by_rest_crud' => true,
 				'inputSchema'         => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -233,6 +237,7 @@ class McpCustomPostTypesTools {
 				'type'                => 'delete',
 				'callback'            => array( $this, 'delete_custom_post_type' ),
 				'permission_callback' => array( $this, 'delete_custom_post_type_permission_callback' ),
+				'disabled_by_rest_crud' => true,
 				'inputSchema'         => array(
 					'type'       => 'object',
 					'properties' => array(

--- a/includes/Tools/McpRestApiCrud.php
+++ b/includes/Tools/McpRestApiCrud.php
@@ -1,0 +1,222 @@
+<?php //phpcs:ignore
+/**
+ * Class McpWordPressRestApi
+ *
+ * Registers generic MCP tools for CRUD actions on any WordPress REST API endpoint.
+ *
+ * @package Automattic\WordpressMcp\Tools
+ */
+declare( strict_types=1 );
+
+namespace Automattic\WordpressMcp\Tools;
+
+use Automattic\WordpressMcp\Core\RegisterMcpTool;
+use WP_REST_Request;
+
+/**
+ * Class McpWordPressRestApi
+ *
+ * Registers generic MCP tools for CRUD actions on any WordPress REST API endpoint.
+ *
+ * @package Automattic\WordpressMcp\Tools
+ */
+class McpRestApiCrud {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'wordpress_mcp_init', array( $this, 'register_tools' ) );
+	}
+
+	/**
+	 * Register generic CRUD tools for a given REST API endpoint.
+	 *
+	 * Example usage: You can extend this to register tools for any custom endpoint.
+	 */
+	public function register_tools(): void {
+		// Check if REST API CRUD tools are enabled in settings
+		$settings = get_option( 'wordpress_mcp_settings', array() );
+		if ( empty( $settings['enable_rest_api_crud_tools'] ) ) {
+			return;
+		}
+
+		// Example: Register CRUD tools for a custom endpoint '/wp/v2/example'.
+		// To use for other endpoints, duplicate and adjust the route/method/name/description as needed.
+
+		new RegisterMcpTool(
+			array(
+				'name'        => 'list_wordpress_rest_api_endpoints',
+				'description' => 'List all available WordPress REST API endpoints and their supported HTTP methods. Use this first to discover what API endpoints are available before making specific calls.',
+				'type'        => 'read',
+				'inputSchema' => array(
+					'type'       => 'object',
+					'properties' => new \stdClass(),
+					'required'   => new \stdClass(),
+				),
+				'callback'    => array( $this, 'get_available_tools' ),
+                'permission_callback' => '__return_true',
+				'annotations' => array(
+					'title'         => 'List REST API Endpoints',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
+			)
+		);
+
+		new RegisterMcpTool(
+			array(
+				'name'        => 'get_wordpress_rest_api_endpoint_schema',
+				'description' => 'Get the complete schema and documentation for a specific WordPress REST API endpoint and HTTP method. Use this to understand what parameters are required and available for an endpoint before making calls.',
+				'type'        => 'read',
+				'inputSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'route'  => array( 
+							'type' => 'string',
+							'description' => 'The REST API route (e.g., "/wp/v2/posts", "/wp/v2/users")'
+						),
+						'method' => array(
+							'type' => 'string',
+							'enum' => array( 'GET', 'POST', 'PATCH', 'DELETE' ),
+							'description' => 'The HTTP method to get schema for'
+						),
+					),
+					'required'   => array( 'route', 'method' ),
+				),
+				'callback'    => array( $this, 'get_tool_details' ),
+                'permission_callback' => '__return_true',
+				'annotations' => array(
+					'title'         => 'Get Endpoint Schema',
+					'readOnlyHint'  => true,
+					'openWorldHint' => false,
+				),
+			)
+		);
+
+		new RegisterMcpTool(
+			array(
+				'name'        => 'call_wordpress_rest_api',
+				'description' => 'Make a direct call to any WordPress REST API endpoint. Supports GET (read), POST (create), PATCH (update), and DELETE operations. Use this to interact with WordPress content like posts, pages, users, etc.',
+				'type'        => 'action',
+				'inputSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'route'  => array( 
+							'type' => 'string',
+							'description' => 'The REST API route (e.g., "/wp/v2/posts", "/wp/v2/users/123")'
+						),
+						'method' => array(
+							'type' => 'string',
+							'enum' => array( 'GET', 'POST', 'PATCH', 'DELETE' ),
+							'description' => 'The HTTP method: GET (read), POST (create), PATCH (update), DELETE (remove)'
+						),
+						'data'   => array( 
+							'type' => 'object',
+							'description' => 'Request body data for POST/PATCH requests. Not needed for GET/DELETE.'
+						),
+					),
+					'required'   => array( 'route', 'method' ),
+				),
+				'callback'    => array( $this, 'handle_tool_run_request' ),
+                'permission_callback' => '__return_true',
+				'annotations' => array(
+					'title'           => 'Call REST API',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => false,
+					'openWorldHint'   => false,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle a REST API request.
+	 *
+	 * @param array $data The request data.
+	 * @return array The response data.
+	 */
+	public function handle_tool_run_request( array $data ): array {
+		$route  = $data['route'];
+		$method = $data['method'];
+		$data   = $data['data'];
+
+		// Get settings to check if operations are enabled
+		$settings = get_option( 'wordpress_mcp_settings', array() );
+
+		// Check if the method is allowed based on settings
+		switch ( $method ) {
+			case 'DELETE':
+				if ( empty( $settings['enable_delete_tools'] ) ) {
+					return array(
+						'error' => 'Delete operations are disabled in MCP settings.',
+						'code'  => 'operation_disabled',
+					);
+				}
+				break;
+			case 'POST':
+				if ( empty( $settings['enable_create_tools'] ) ) {
+					return array(
+						'error' => 'Create operations are disabled in MCP settings.',
+						'code'  => 'operation_disabled',
+					);
+				}
+				break;
+			case 'PATCH':
+			case 'PUT':
+				if ( empty( $settings['enable_update_tools'] ) ) {
+					return array(
+						'error' => 'Update operations are disabled in MCP settings.',
+						'code'  => 'operation_disabled',
+					);
+				}
+				break;
+		}
+
+		$rest_request = new WP_REST_Request( $method, $route );
+		$rest_request->set_body_params( $data );
+		$response = rest_do_request( $rest_request );
+		return $response->get_data();
+	}
+
+	/**
+	 * Get all routes and methods from the WordPress REST API.
+	 *
+	 * @return array The routes and methods.
+	 */
+	public function get_available_tools(): array {
+		// content.text.result[key]
+		// get all routes and methods from the WordPress rest api.
+		$routes = rest_get_server()->get_routes();
+		foreach ( $routes as $route => $methods ) {
+			foreach ( $methods as $the_methods ) {
+				$result[] = array(
+					'route'  => $route,
+					'method' => key( $the_methods['methods'] ),
+				);
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Get details of a WordPress REST API tool.
+	 *
+	 * @param array $data The request data.
+	 * @return array|null The response data.
+	 */
+	public function get_tool_details( array $data ): array {
+		$route  = $data['route'];
+		$method = $data['method'];
+
+		$routes = rest_get_server()->get_routes();
+		foreach ( $routes as $route => $methods ) {
+			foreach ( $methods as $method => $args ) {
+				if ( $route === $route && $method === $method ) {
+					return $args;
+				}
+			}
+		}
+		return array();
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wordpress-mcp",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A plugin to integrate WordPress with Model Context Protocol (MCP), providing AI-accessible interfaces to WordPress data and functionality through standardized tools, resources, and prompts. Enables AI assistants to interact with posts, users, site settings, and WooCommerce data.",
     "keywords": [
         "wordpress",
@@ -27,7 +27,7 @@
         "lint:js": "wp-scripts lint-js",
         "packages-update": "wp-scripts packages-update",
         "plugin-zip": "wp-scripts plugin-zip",
-        "plugin-zip:build": "composer install --no-dev && npm run build && npm run plugin-zip",
+        "plugin-zip:build": "composer install --no-dev && pnpm run build && pnpm run plugin-zip",
         "clean": "rm -rf build"
     },
     "dependencies": {

--- a/src/settings/SettingsTab.js
+++ b/src/settings/SettingsTab.js
@@ -19,30 +19,40 @@ import { useEffect } from '@wordpress/element';
 const SettingsTab = ( { settings, onToggleChange, isSaving, strings } ) => {
 	// Check if WordPress Features API is available
 	// When passing from PHP to JS via wp_localize_script, booleans become strings
-	const isFeatureApiAvailable = 
-		window.wordpressMcpSettings?.featureApiAvailable === true || 
+	const isFeatureApiAvailable =
+		window.wordpressMcpSettings?.featureApiAvailable === true ||
 		window.wordpressMcpSettings?.featureApiAvailable === '1';
-	
+
 	// Add debugging - can be removed after fixing the issue
-	useEffect(() => {
-		console.log('[DEBUG] Feature API available:', isFeatureApiAvailable);
-		console.log('[DEBUG] MCP Settings object:', window.wordpressMcpSettings);
-	}, [isFeatureApiAvailable]);
-	
+	useEffect( () => {}, [ isFeatureApiAvailable ] );
+
 	// Determine if the feature toggle should be disabled
-	const isFeatureToggleDisabled = !settings.enabled || !isFeatureApiAvailable;
-	
+	const isFeatureToggleDisabled =
+		! settings.enabled || ! isFeatureApiAvailable;
+
 	// Create the help text with link for Feature API
 	const featureApiHelpText = isFeatureApiAvailable
-		? (strings.enableFeaturesAdapterDescription || 
-		   __('Enable or disable the WordPress Features Adapter. This option only works when MCP is enabled.', 'wordpress-mcp'))
+		? strings.enableFeaturesAdapterDescription ||
+		  __(
+				'Enable or disable the WordPress Features Adapter. This option only works when MCP is enabled.',
+				'wordpress-mcp'
+		  )
 		: createInterpolateElement(
-			__('WordPress Feature API is not available. Please <a>install</a> and activate the WordPress Feature API plugin.', 'wordpress-mcp'),
-			{
-				a: <a href="https://github.com/Automattic/wp-feature-api" target="_blank" rel="noopener noreferrer" />
-			}
-		);
-	
+				__(
+					'WordPress Feature API is not available. Please <a>install</a> and activate the WordPress Feature API plugin.',
+					'wordpress-mcp'
+				),
+				{
+					a: (
+						<a
+							href="https://github.com/Automattic/wp-feature-api"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				}
+		  );
+
 	return (
 		<Card>
 			<CardHeader>
@@ -77,41 +87,101 @@ const SettingsTab = ( { settings, onToggleChange, isSaving, strings } ) => {
 							)
 						}
 						help={ featureApiHelpText }
-						checked={ isFeatureApiAvailable ? settings.features_adapter_enabled : false }
+						checked={
+							isFeatureApiAvailable
+								? settings.features_adapter_enabled
+								: false
+						}
 						onChange={ () => {
-							if (isFeatureApiAvailable && settings.enabled) {
-								onToggleChange('features_adapter_enabled');
+							if ( isFeatureApiAvailable && settings.enabled ) {
+								onToggleChange( 'features_adapter_enabled' );
 							}
-						}}
+						} }
 						disabled={ isFeatureToggleDisabled }
 					/>
 				</div>
 
 				<div className="setting-row">
 					<ToggleControl
-						label={strings.enableCreateTools || __('Enable Create Tools', 'wordpress-mcp')}
-						help={strings.enableCreateToolsDescription || __('Allow create operations via tools.', 'wordpress-mcp')}
-						checked={settings.enable_create_tools}
-						onChange={() => onToggleChange('enable_create_tools')}
-						disabled={!settings.enabled}
+						label={
+							strings.enableCreateTools ||
+							__( 'Enable Create Tools', 'wordpress-mcp' )
+						}
+						help={
+							strings.enableCreateToolsDescription ||
+							__(
+								'Allow create operations via tools.',
+								'wordpress-mcp'
+							)
+						}
+						checked={ settings.enable_create_tools }
+						onChange={ () =>
+							onToggleChange( 'enable_create_tools' )
+						}
+						disabled={ ! settings.enabled }
 					/>
 				</div>
 				<div className="setting-row">
 					<ToggleControl
-						label={strings.enableUpdateTools || __('Enable Update Tools', 'wordpress-mcp')}
-						help={strings.enableUpdateToolsDescription || __('Allow update operations via tools.', 'wordpress-mcp')}
-						checked={settings.enable_update_tools}
-						onChange={() => onToggleChange('enable_update_tools')}
-						disabled={!settings.enabled}
+						label={
+							strings.enableUpdateTools ||
+							__( 'Enable Update Tools', 'wordpress-mcp' )
+						}
+						help={
+							strings.enableUpdateToolsDescription ||
+							__(
+								'Allow update operations via tools.',
+								'wordpress-mcp'
+							)
+						}
+						checked={ settings.enable_update_tools }
+						onChange={ () =>
+							onToggleChange( 'enable_update_tools' )
+						}
+						disabled={ ! settings.enabled }
 					/>
 				</div>
 				<div className="setting-row">
 					<ToggleControl
-						label={strings.enableDeleteTools || __('Enable Delete Tools', 'wordpress-mcp')}
-						help={strings.enableDeleteToolsDescription || __('⚠️ CAUTION: Allow deletion operations via tools.', 'wordpress-mcp')}
-						checked={settings.enable_delete_tools}
-						onChange={() => onToggleChange('enable_delete_tools')}
-						disabled={!settings.enabled}
+						label={
+							strings.enableDeleteTools ||
+							__( 'Enable Delete Tools', 'wordpress-mcp' )
+						}
+						help={
+							strings.enableDeleteToolsDescription ||
+							__(
+								'⚠️ CAUTION: Allow deletion operations via tools.',
+								'wordpress-mcp'
+							)
+						}
+						checked={ settings.enable_delete_tools }
+						onChange={ () =>
+							onToggleChange( 'enable_delete_tools' )
+						}
+						disabled={ ! settings.enabled }
+					/>
+				</div>
+				<div className="setting-row">
+					<ToggleControl
+						label={
+							strings.enableRestApiCrudTools ||
+							__(
+								'🧪 Enable REST API CRUD Tools (EXPERIMENTAL)',
+								'wordpress-mcp'
+							)
+						}
+						help={
+							strings.enableRestApiCrudToolsDescription ||
+							__(
+								'⚠️ EXPERIMENTAL FEATURE: Enable or disable the generic REST API CRUD tools for accessing WordPress endpoints. This is experimental functionality that may change or be removed in future versions. When enabled, all tools that are a rest_alias or have the disabled_by_rest_crud flag will be disabled.',
+								'wordpress-mcp'
+							)
+						}
+						checked={ settings.enable_rest_api_crud_tools }
+						onChange={ () =>
+							onToggleChange( 'enable_rest_api_crud_tools' )
+						}
+						disabled={ ! settings.enabled }
 					/>
 				</div>
 			</CardBody>

--- a/wordpress-mcp.php
+++ b/wordpress-mcp.php
@@ -2,7 +2,7 @@
 /**
  * Plugin name:       WordPress MCP
  * Description:       A plugin to integrate WordPress with Model Context Protocol (MCP), providing AI-accessible interfaces to WordPress data and functionality through standardized tools, resources, and prompts. Enables AI assistants to interact with posts, users, site settings, and WooCommerce data.
- * Version:           0.2.0
+ * Version:           0.2.1
  * Requires at least: 6.4
  * Requires PHP:      8.0
  * Author:            Automattic AI, Ovidiu Galatan <ovidiu.galatan@a8c.com>


### PR DESCRIPTION
- Added a new McpRestApiCrud class to register generic CRUD tools for WordPress REST API endpoints.
- Introduced settings for enabling/disabling REST API CRUD tools in the admin interface, including descriptions for user guidance.
- Updated existing tools to include a 'disabled_by_rest_crud' flag for better control over tool availability based on settings.
- Modified package.json to use pnpm for building the plugin zip.
- Enhanced the SettingsTab component to include toggles for the new REST API CRUD tools feature.