### PR TITLE
fix: use get_all_tools() in list_all_tools() to include tool state information

### DIFF
--- a/includes/RequestMethodHandlers/ToolsHandler.php
+++ b/includes/RequestMethodHandlers/ToolsHandler.php
@@ -49,7 +49,7 @@ class ToolsHandler {
 	 */
 	public function list_all_tools(): array {
 		// Return all tools with additional details.
-		$tools = $this->mcp->get_tools();
+		$tools = $this->mcp->get_all_tools();
 
 		// Add any additional metadata or details.
 		foreach ( $tools as &$tool ) {


### PR DESCRIPTION


The ToolsHandler::list_all_tools() method was calling get_tools() instead of get_all_tools(), which meant the frontend wasn't receiving the tool_type_enabled and tool_enabled properties needed to properly control tool toggles.

- get_tools() returns only registered tools without state properties
- get_all_tools() returns all tools with complete state information
- This fix allows the admin interface to properly enable/disable individual tool toggles